### PR TITLE
Fixed typo

### DIFF
--- a/src/documentation/0028-npx/index.md
+++ b/src/documentation/0028-npx/index.md
@@ -20,7 +20,7 @@ Running `npx commandname` automatically finds the correct reference of the comma
 
 ## Installation-less command execution
 
-There is another great feature of `npm`, which is allowing to run commands without first installing them.
+There is another great feature of `npx`, which is allowing to run commands without first installing them.
 
 This is pretty useful, mostly because:
 


### PR DESCRIPTION
Fixed typo with `NPM` that should be `NPX` instead.